### PR TITLE
Check IP with Symfony HttpFoundation IpUtils to allow the use of a netmask in the allowed IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ ezpublish:
         default:
             maintenance_mode:
                 enabled: true
-                allowed_ips: ['::1', '10.0.0.1']
+                allowed_ips: ['::1', '10.0.0.1', '192.168.0.0/16']
                 response_code: 404
                 template: '@Acme/custom_maintenance.html.twig'
 ```

--- a/src/bundle/Event/Subscriber/MaintenanceModeSubscriber.php
+++ b/src/bundle/Event/Subscriber/MaintenanceModeSubscriber.php
@@ -9,6 +9,7 @@ namespace EzSystems\EzPlatformMaintenanceModeBundle\Event\Subscriber;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\IpUtils;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Twig\Environment;
@@ -61,7 +62,7 @@ final class MaintenanceModeSubscriber implements EventSubscriberInterface
 
         $allowedIps = $this->configResolver->getParameter('maintenance_mode.allowed_ips');
 
-        if (\in_array($request->getClientIp(), $allowedIps, true)) {
+        if (IpUtils::checkIp($request->getClientIp(), $allowedIps)) {
             return;
         }
 


### PR DESCRIPTION
Replaced the IP check to use `\Symfony\Component\HttpFoundation\IpUtils::checkIp` function so we can use netmask in the allowed ip array as showed in the updated readme.